### PR TITLE
Update to express 4.4.x, include connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "preferGlobal": true,
   "dependencies": {
     "workshopper": "~0.3.3",
-    "express": "~3.4.3",
+    "express": "~4.4.2",
     "superagent": "~0.15.7",
     "jade": "~0.35.0",
-    "stylus": "~0.38.0"
+    "stylus": "~0.38.0",
+    "connect": "~2.19.5"
   }
 }


### PR DESCRIPTION
Riding on the heels of pull request #24, this updates the dependencies to express 4.4.x and includes connect as a dependency (which is required with pull request #24).

We’re seeing failures with the “what’s in query” problem when using express 4 vs express 3.  Most new users default to use express 4, so by including express 4 in expressworks, the problem solutions should align.  More information can be found in this nodeschool issue: https://github.com/nodeschool/discussions/issues/327.

I have verified all solutions pass (assuming pull request #24 was included) after applying these changes (when the nodeschool user is using the latest versions of dependencies).
