### PR TITLE
stylish_css: location of HTML files made explicit

### DIFF
--- a/problems/stylish_css/problem.txt
+++ b/problems/stylish_css/problem.txt
@@ -1,4 +1,6 @@
-Style your HTML from previous example with some Stylus middleware. Your solution must listen on the port number supplied by process.argv[2]. The path to main.styl file is provided in process.argv[3] or you can create your own file/folder from these:
+Style your HTML from previous example with some Stylus middleware. Your solution must listen on the port number supplied by process.argv[2]. The path containing the HTML and Stylus files is provided in process.argv[3] (they are in the same directory). You can create your own folder and use these:
+
+The main.styl file:
 
   p
     color red


### PR DESCRIPTION
In the stylish_css exercise the location of the HTML files is not made explicit; only the Stylus files. This minor change makes the location of the HTML files explicit.
