### PR TITLE
Use bodyParser instead of connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "bin": "./expressworks.js",
   "preferGlobal": true,
   "dependencies": {
-    "workshopper": "~0.3.3",
+    "body-parser": "^1.5.1",
     "express": "~4.4.2",
-    "superagent": "~0.15.7",
     "jade": "~0.35.0",
     "stylus": "~0.38.0",
-    "connect": "~2.19.5"
+    "superagent": "~0.15.7",
+    "workshopper": "~0.3.3"
   }
 }

--- a/problems/good_old_form/problem.txt
+++ b/problems/good_old_form/problem.txt
@@ -8,17 +8,21 @@ To handle POST request use the post() method which is used the same way as get()
 
   app.post('/path', function(req, res){...})
 
-Express.js use middleware to provide extra functionality to your web server.
+Express.js uses middleware to provide extra functionality to your web server.
 Simply put, a middleware is a function invoked by Express.js before your own request handler.
 Middlewares provide a large variety of functionalities such as logging, serving static files and error handling.
 A middleware is added by calling use() on the application and passing the middleware as a parameter.
 
-To parse x-ww-form-urlencoded request bodies Express.js can use urlencoded() middleware (from Connect library):
+To parse x-www-form-urlencoded request bodies Express.js can use urlencoded() middleware
+from the body-parser module.
 
-  app.use(connect.urlencoded())
+  var bodyparser = require('body-parser')
+  app.use(bodyparser.urlencoded({extended: false}))
 
-Read more about Connect here:
-  http://www.senchalabs.org/connect
+Read more about Connect middleware here:
+  https://github.com/senchalabs/connect#middleware
+The documentation of the body-parser module can be found here:
+  https://github.com/expressjs/body-parser
 
 Here is how we can flip the characters:
 
@@ -27,8 +31,7 @@ Here is how we can flip the characters:
 
 NOTE
 
-Avoid using soon to be depricated bodyParser() middleware.
-
-When creating your projects from scratch, install connect dependency with NPM.
+When creating your projects from scratch, install the body-parser dependency with npm by
+running npm install body-parser in your terminal.
 
 Again, the port to use is passed {appname} to the application as process.argv[2].

--- a/problems/good_old_form/solution.js
+++ b/problems/good_old_form/solution.js
@@ -1,8 +1,8 @@
 var express = require('express')
-var connect = require('connect')
+var bodyParser = require('body-parser')
 var app = express()
 
-app.use(connect.urlencoded())
+app.use(bodyParser.urlencoded({extended: false}))
 
 app.post('/form', function(req, res) {
   res.send(req.body.str.split('').reverse().join(''))


### PR DESCRIPTION
As mentioned in #28, the use of the connect body-parser middleware is deprecated. So I changed the tasks and solution to use the body-parser module instead.

Best,
Finn
