### PR TITLE
CRITICAL: missing dep makes workshop fail when starting an exercise.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "stylus": "^0.50.0",
     "superagent": "~0.15.7",
     "through2": "^0.6.3",
-    "workshopper": "^2.3.1"
+    "workshopper": "^2.3.1",
+    "workshopper-exercise": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hey Azat,

So sorry, I missed a critical explicit dep in my PR, on `workshopper-exercise`. Starting any exercise will fail without it. I had installed it another way that hadn't involved updating `package.json`.

I cross my fingers super hard for you to see this very quickly and be able to merge and bump on npm!

Best,