### PR TITLE
fixed verify ECONNREFUSED error

### DIFF
--- a/exercises/good_old_form/exercise.js
+++ b/exercises/good_old_form/exercise.js
@@ -34,7 +34,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/hello_world/exercise.js
+++ b/exercises/hello_world/exercise.js
@@ -33,7 +33,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 3000)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/hello_world/exercise.js
+++ b/exercises/hello_world/exercise.js
@@ -33,7 +33,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 3000)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/jade/exercise.js
+++ b/exercises/jade/exercise.js
@@ -34,7 +34,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/json_me/exercise.js
+++ b/exercises/json_me/exercise.js
@@ -34,7 +34,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/param_pam_pam/exercise.js
+++ b/exercises/param_pam_pam/exercise.js
@@ -33,7 +33,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/static/exercise.js
+++ b/exercises/static/exercise.js
@@ -34,7 +34,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/stylish_css/exercise.js
+++ b/exercises/stylish_css/exercise.js
@@ -34,7 +34,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 1000)
+  setTimeout(query.bind(this, mode), 2000)
 
   process.nextTick(function () {
     callback(null, true)

--- a/exercises/whats_in_query/exercise.js
+++ b/exercises/whats_in_query/exercise.js
@@ -33,7 +33,7 @@ exercise.addProcessor(function (mode, callback) {
   if (mode == 'verify')
     this.solutionStdout = through2()
 
-  setTimeout(query.bind(this, mode), 500)
+  setTimeout(query.bind(this, mode), 1500)
 
   process.nextTick(function () {
     callback(null, true)


### PR DESCRIPTION
Changed timeout from 500 to 1500 and 1000 to 2000 in `exercise.js` files so as to prevent `ECONNREFUSED` when verifying (i.e. `$ expressworks verify app.js`).

`setTimeout(query.bind(this, mode), 500)` → `setTimeout(query.bind(this, mode), 1500)`