### PR TITLE
Duplicate text in hello_world problem.md

### DIFF
--- a/exercises/hello_world/problem.md
+++ b/exercises/hello_world/problem.md
@@ -3,7 +3,7 @@ Create an Express.js app that outputs "Hello World!" when somebody goes to `/hom
 The port number will be provided to you by {appname} as the first argument of
 the application, i.e., `process.argv[2]`.
 
-Run `$ killall node`  before verifying exercises (in your terminal on Mac OS X) to end any previous processes. For Windows, use `taskkill /IM node.exe` in Command Prompt.
+Run `$ killall node`  before verifying exercises (in your terminal on Mac OS X) to end any previous processes.
 
 For Windows, use "taskkill /IM node.exe" in Command Prompt.
 


### PR DESCRIPTION
The following sentence appears twice: "For Windows, use "taskkill /IM node.exe" in Command Prompt."

This file change proposes removing one of the sentences.