### PR TITLE
Upgrade workshopper-excercise to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "superagent": "~0.15.7",
     "through2": "^0.6.3",
     "workshopper": "^2.6.0",
-    "workshopper-exercise": "^2.4.0"
+    "workshopper-exercise": "^2.5.3"
   }
 }


### PR DESCRIPTION
- Fixes an error where verify complains of an Invalid array length