### PR TITLE
Clarify Instructions in Good Old Form

### DIFF
--- a/exercises/good_old_form/problem.md
+++ b/exercises/good_old_form/problem.md
@@ -1,7 +1,7 @@
 Forms are important. This exercise will teach you how to process the traditional (non-AJAX) web form.
 
 Write a route (`'/form'`) that processes HTML form input
-(`<form><input name="str"/></form>`) and prints the value of `str` backwards.
+(`<form><input name="str"/></form>`) and responds with the value of `str` backwards.
 
 To handle a POST request, use the `post()` method which is used the same way as `get()`:
 


### PR DESCRIPTION
In the instructions, `print` implies that you want to `console.log` the reversed string, when you actually want to respond with the reversed string.

This PR fixes that.