### PR TITLE
Added missing port requirement to specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You might want to download [the free Express.js cheatsheet](https://gumroad.com/
  1  swisherb
  1  tdtsh
  1  Victor Hugo Rocha
+ 1  Bradley Hanson
 ```
 
 Make a PR to see your name here. ;-)

--- a/exercises/param_pam_pam/problem.md
+++ b/exercises/param_pam_pam/problem.md
@@ -22,6 +22,8 @@ require('crypto')
   .digest('hex')
 ```
 
+Your solution must listen on the port number supplied by `process.argv[2]`.
+
 -----------------------------
 
 ## HINTS

--- a/exercises/whats_in_query/problem.md
+++ b/exercises/whats_in_query/problem.md
@@ -12,6 +12,8 @@ In Express.js, to extract query string parameters, we can use (inside the reques
 req.query.NAME
 ```
 
+Your solution must listen on the port number supplied by `process.argv[2]`.
+
 -----------------------------
 
 ## HINTS


### PR DESCRIPTION
All of the other exercises explicitly list the port requirement except for these two.  