### PR TITLE
Add support for spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,41 +41,47 @@ You might want to download [the free Express.js cheatsheet](https://gumroad.com/
 
 ## Contributors
 
-
 ```
-105  Azat Mardan
+117  Azat Mardan
 55  Azat Mardanov
 19  Christophe Porteneuve
 10  Tyler Moeller
 10  azat-co
  9  RamiroPinol
- 8  Justin Porter
  8  Elias Meire
+ 8  Justin Porter
  6  billy3321
  4  Kohei TAKATA
+ 4  Shim Won
  3  Charlotte Spencer
  3  Harry Moreno
+ 3  Kaelig Deloumeau-Prigent
  2  Austin Corso
  2  Julian Mazzitelli
  2  Kevin Jayanthan
  2  Robbie Holmes
- 2  Shim Won
  2  Thomas Burette
+ 2  Victor Hugo
  2  intrueder
  1  Alessandro Lensi
  1  Alfredo Miranda
+ 1  Apricity
  1  Ayman Mahfouz
+ 1  Chuanfeng
  1  Daniel Geier
  1  Dylan Smith
  1  Eddie Hsieh
  1  Finn
  1  Gabe Fernando
  1  Giuseppe
+ 1  Hanbyul Jin
  1  Jessie Shi
  1  Johan Binard
  1  Jonny Arnold
  1  Kevin Kuhl
  1  Louis Pilfold
+ 1  Luis Del Águila
+ 1  Naitian Zhou
  1  Rich Trott
  1  Richard Kho
  1  Ryan Kois
@@ -86,7 +92,6 @@ You might want to download [the free Express.js cheatsheet](https://gumroad.com/
  1  raj
  1  swisherb
  1  tdtsh
- 1  Victor Hugo Rocha
 ```
 
 Make a PR to see your name here. ;-)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You might want to download [the free Express.js cheatsheet](https://gumroad.com/
 ## Languages
 
 * English
+* Spanish
 * French
 * Simplified Chinese
 * Traditional Chinese

--- a/expressworks.js
+++ b/expressworks.js
@@ -10,6 +10,6 @@ function fpath (f) {
 Workshopper({
     name      : 'expressworks'
   , appDir    : __dirname
-  , languages : ['en', 'fr', 'ko', 'zh-tw', 'ja','zh-cn', 'pt-br']
+  , languages : ['en', 'es', 'fr', 'ko', 'zh-tw', 'ja','zh-cn', 'pt-br']
   , helpFile  : fpath('./i18n/help/{lang}.txt')
 })

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,0 +1,26 @@
+{
+  "title": "¡Domina Express.js y diviértete!",
+  "subtitle" : "\u001b[23mSelecciona un ejercicio y presiona \u001b[3mEnter\u001b[23m para empezar",
+  "common": {
+    "exercise": {
+      "fail": {
+        "connection": "Error conectándose a {{{address}}}: {{{message}}}"
+      }
+    }
+  },
+  "exercises": {
+    "good_old_form": {
+      "source": "¡Express.js es lo máximo!"
+    }
+  },
+  "exercise": {
+    "HELLO WORLD!": "¡HOLA, MUNDO!",
+    "PUG": "PUG",
+    "GOOD OLD FORM": "EL CLÁSICO FORMULARIO",
+    "STATIC": "STATIC",
+    "STYLISH CSS": "ESTILIZANDO CON CSS",
+    "PARAM PAM PAM": "PARAM PAM PAM",
+    "WHAT'S IN QUERY": "¿QUÉ HAY EN EL QUERY?",
+    "JSON ME": "VUÉLVEME JSON"
+  }
+}

--- a/i18n/help/es.txt
+++ b/i18n/help/es.txt
@@ -1,0 +1,17 @@
+Bienvenido a ExpressWorks - un taller para el framework Express.js.
+Este taller está basado en workshopper e inspirado por stream-adventure, de @substack y @maxogden
+
+Documentación del API:
+
+http://expressjs.com/es/api.html
+
+Guía de Express.js:
+
+http://expressjsguide.com/
+
+
+¿Problemas? ¿Sugerencias? ¿Retroalimentación?
+
+https://github.com/azat-co/expressworks/issues
+
+Otros talleres geniales: https://nodeschool.io/es/


### PR DESCRIPTION
Although @RamiroPinol added some awesome translations for all the exercises in #117, the spanish (es) language was not added to the Workshopper configuration.

This PR adds spanish, translates the menu and help, updates the README, and updates the contributors list.