### PR TITLE
Use workshopper-adventure

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,39 +42,46 @@ You might want to download [the free Express.js cheatsheet](https://gumroad.com/
 
 
 ```
-105  Azat Mardan
+117  Azat Mardan
 55  Azat Mardanov
 19  Christophe Porteneuve
 10  Tyler Moeller
 10  azat-co
  9  RamiroPinol
- 8  Justin Porter
  8  Elias Meire
+ 8  Justin Porter
  6  billy3321
  4  Kohei TAKATA
+ 4  Shim Won
  3  Charlotte Spencer
  3  Harry Moreno
+ 3  Kaelig Deloumeau-Prigent
  2  Austin Corso
  2  Julian Mazzitelli
  2  Kevin Jayanthan
  2  Robbie Holmes
- 2  Shim Won
  2  Thomas Burette
+ 2  Victor Hugo
  2  intrueder
  1  Alessandro Lensi
  1  Alfredo Miranda
+ 1  Apricity
  1  Ayman Mahfouz
+ 1  Chuanfeng
  1  Daniel Geier
  1  Dylan Smith
  1  Eddie Hsieh
  1  Finn
  1  Gabe Fernando
  1  Giuseppe
+ 1  Hanbyul Jin
  1  Jessie Shi
  1  Johan Binard
  1  Jonny Arnold
  1  Kevin Kuhl
  1  Louis Pilfold
+ 1  Luis Del Águila
+ 1  Naitian Zhou
  1  Rich Trott
  1  Richard Kho
  1  Ryan Kois
@@ -85,7 +92,6 @@ You might want to download [the free Express.js cheatsheet](https://gumroad.com/
  1  raj
  1  swisherb
  1  tdtsh
- 1  Victor Hugo Rocha
 ```
 
 Make a PR to see your name here. ;-)

--- a/bin/expressworks.js
+++ b/bin/expressworks.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../expressworks').execute(process.argv.slice(2))

--- a/expressworks.js
+++ b/expressworks.js
@@ -1,15 +1,24 @@
-#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+const Workshopper = require('workshopper-adventure')
+const usage = require('workshopper-adventure/default/help').file[0]
+const menu = require('./exercises/menu.json')
 
-const Workshopper = require('workshopper')
-    , path        = require('path')
+const help = path.join(__dirname, './i18n/help/{lang}.txt')
 
-function fpath (f) {
-  return path.join(__dirname, f)
-}
-
-Workshopper({
-    name      : 'expressworks'
-  , appDir    : __dirname
-  , languages : ['en', 'fr', 'ko', 'zh-tw', 'ja','zh-cn', 'pt-br']
-  , helpFile  : fpath('./i18n/help/{lang}.txt')
+const expressworks = Workshopper({
+  appDir: __dirname,
+  languages: ['en', 'fr', 'ko', 'zh-tw', 'ja','zh-cn', 'pt-br'],
+  footer: require('workshopper-adventure/default/footer'),
+  help: function (i18n, lang) {
+    return [usage, help].map(function (file) {
+      file = file.replace(/\{?\{lang\}?\}/g, lang)
+      const content = fs.readFileSync(file)
+      return '---\n' + content
+    })
+  }
 })
+
+expressworks.addAll(menu)
+
+module.exports = expressworks

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/azat-co/expressworks/issues"
   },
-  "bin": "./expressworks.js",
+  "bin": "./bin/expressworks.js",
   "preferGlobal": true,
   "dependencies": {
     "body-parser": "^1.12.0",
@@ -30,7 +30,7 @@
     "stylus": "^0.50.0",
     "superagent": "~0.15.7",
     "through2": "^0.6.3",
-    "workshopper": "^2.6.0",
+    "workshopper-adventure": "^6.0.4",
     "workshopper-exercise": "^2.5.3"
   }
 }


### PR DESCRIPTION
Use workshopper-adventure instead of workshopper.
The main win of switching is to use a newer version of the `msee` dependency, since the version in use is not properly rendering links.